### PR TITLE
feat: Add feature flags in CloudWatch metric stream module outputs

### DIFF
--- a/examples/cloudwatch/metric-stream/basic/outputs.tf
+++ b/examples/cloudwatch/metric-stream/basic/outputs.tf
@@ -8,6 +8,11 @@ output "tags_set" {
   description = "The tags set for the module."
 }
 
+output "feature_flags" {
+  value       = module.main_module.feature_flags
+  description = "The feature flags for the module."
+}
+
 output "cloudwatch_metric_stream_id" {
   value       = module.main_module.cloudwatch_metric_stream_id
   description = "The ID of the CloudWatch Metric Stream."

--- a/examples/cloudwatch/metric-stream/basic/providers.tf
+++ b/examples/cloudwatch/metric-stream/basic/providers.tf
@@ -1,1 +1,3 @@
-provider "aws" {}
+provider "aws" {
+  region = "us-east-1"
+}

--- a/modules/cloudwatch/metric-stream/locals.tf
+++ b/modules/cloudwatch/metric-stream/locals.tf
@@ -7,7 +7,10 @@ locals {
   # 1. `is_stream_enabled` - Flag to enable or disable the CloudWatch metric stream that's built-in to the module.
   #
   ###################################
-  is_stream_enabled = var.is_enabled && var.stream != null
+  is_stream_enabled                   = var.is_enabled && var.stream != null
+  is_statistics_configuration_enabled = !local.is_stream_enabled ? false : var.statistics_configurations == null ? false : length(var.statistics_configurations) > 0
+  is_include_filters_enabled          = !local.is_stream_enabled ? false : var.include_filters == null ? false : length(var.include_filters) > 0
+  is_exclude_filters_enabled          = !local.is_stream_enabled ? false : var.exclude_filters == null ? false : length(var.exclude_filters) > 0
 
   ###################################
   # Normalized & Cleaned Variables 🧹
@@ -22,57 +25,62 @@ locals {
   ###################################
   # 🧹 `stream_name`: Normalized to remove any leading or trailing whitespace.
   # Ensures the name is clean and formatted correctly.
-  stream_name = local.is_stream_enabled && var.stream.name != null ? trimspace(var.stream.name) : ""
+  stream_name = !local.is_stream_enabled ? "" : var.stream.name == null ? "" : trimspace(var.stream.name)
 
   # 🧹 `firehose_arn`: Cleaned to ensure it follows the correct ARN pattern.
   # This prevents errors related to malformed ARNs.
-  firehose_arn = local.is_stream_enabled && var.stream.firehose_arn != null ? trimspace(var.stream.firehose_arn) : ""
+  firehose_arn = !local.is_stream_enabled ? "" : var.stream.firehose_arn == null ? "" : trimspace(var.stream.firehose_arn)
 
   # 🧹 `role_arn`: Cleaned to ensure it follows the correct ARN pattern.
   # Ensures the IAM role ARN is correctly formatted.
-  role_arn = local.is_stream_enabled && var.stream.role_arn != null ? trimspace(var.stream.role_arn) : ""
+  role_arn = !local.is_stream_enabled ? "" : var.stream.role_arn == null ? "" : trimspace(var.stream.role_arn)
 
   # 🧹 `output_format`: Normalized to lowercase to ensure consistency.
   # This prevents case sensitivity issues and ensures the value is one of the expected formats.
-  output_format = local.is_stream_enabled && var.stream.output_format != null ? lower(trimspace(var.stream.output_format)) : ""
+  output_format = !local.is_stream_enabled ? "" : var.stream.output_format == null ? "" : lower(trimspace(var.stream.output_format))
 
   # 🧹 `include_filters`: Normalizes each filter by trimming whitespace from namespace and metrics.
   # Ensures clean and correctly formatted filter values.
-  include_filters = local.is_stream_enabled && var.stream.include_filters != null ? [
-    for filter in var.stream.include_filters : {
-      namespace = trimspace(filter.namespace)                                                      # 🧹 Trims whitespace from namespace.
-      metrics   = filter.metrics != null ? [for metric in filter.metrics : trimspace(metric)] : [] # 🧹 Trims whitespace from each metric.
+  include_filters = !local.is_include_filters_enabled ? [] : [
+    for filter in var.include_filters : {
+      namespace = trimspace(filter["namespace"])                                                                   # 🧹 Trims whitespace from namespace.
+      metrics   = filter["metric_names"] == null ? [] : [for metric in filter["metric_names"] : trimspace(metric)] # 🧹 Trims whitespace from each metric.
     }
-  ] : []
+  ]
 
   # 🧹 `exclude_filters`: Normalizes each filter by trimming whitespace from namespace and metrics.
   # Ensures clean and correctly formatted filter values.
-  exclude_filters = local.is_stream_enabled && var.stream.exclude_filters != null ? [
-    for filter in var.stream.exclude_filters : {
-      namespace = trimspace(filter.namespace)                                                      # 🧹 Trims whitespace from namespace.
-      metrics   = filter.metrics != null ? [for metric in filter.metrics : trimspace(metric)] : [] # 🧹 Trims whitespace from each metric.
+  exclude_filters = !local.is_exclude_filters_enabled ? [] : [
+    for filter in var.exclude_filters : {
+      namespace = trimspace(filter["namespace"])                                                                   # 🧹 Trims whitespace from namespace.
+      metrics   = filter["metric_names"] == null ? [] : [for metric in filter["metric_names"] : trimspace(metric)] # 🧹 Trims whitespace from each metric.
     }
-  ] : []
-
+  ]
   # 🧹 `statistics_configurations`: Normalizes each configuration by trimming whitespace from namespace, metric names, and statistics.
   # Ensures clean and correctly formatted configuration values.
-  statistics_configurations = local.is_stream_enabled && var.stream.statistics_configurations != null ? [
-    for config in var.stream.statistics_configurations : {
-      namespace    = trimspace(config.namespace)                         # 🧹 Trims whitespace from namespace.
-      metric_names = [for name in config.metric_names : trimspace(name)] # 🧹 Trims whitespace from each metric name.
-      statistics   = [for stat in config.statistics : trimspace(stat)]   # 🧹 Trims whitespace from each statistic.
+  statistics_configurations = !local.is_statistics_configuration_enabled ? [] : [
+    for config in var.statistics_configurations : {
+      namespace             = trimspace(config.namespace)                                  # 🧹 Trims whitespace from namespace.
+      metric_name           = trimspace(config.metric_name)                                # 🧹 Trims whitespace from metric name.
+      additional_statistics = [for stat in config.additional_statistics : trimspace(stat)] # 🧹 Trims whitespace from each statistic.
+      include_metrics = config.include_metrics == null ? [] : [
+        for metric in config.include_metrics : {
+          metric_name = trimspace(metric.metric_name)
+          namespace   = trimspace(metric.namespace)
+        }
+      ]
     }
-  ] : []
+  ]
 
   # 🧹 `additional_statistics`: Normalizes each additional statistic by trimming whitespace from namespace, metric names, and statistics.
   # Ensures clean and correctly formatted configuration values.
-  additional_statistics = local.is_stream_enabled && var.additional_statistics != null ? [
-    for config in var.additional_statistics : {
+  additional_statistics = !local.is_statistics_configuration_enabled ? [] : [
+    for config in var.statistics_configurations.additional_statistics : {
       namespace    = trimspace(config.namespace)                         # 🧹 Trims whitespace from namespace.
       metric_names = [for name in config.metric_names : trimspace(name)] # 🧹 Trims whitespace from each metric name.
       statistics   = [for stat in config.statistics : trimspace(stat)]   # 🧹 Trims whitespace from each statistic.
     }
-  ] : []
+  ]
 
   # 🧹 `include_linked_accounts_metrics`: Uses the provided value or defaults to false.
   # Ensures a boolean value is always available.

--- a/modules/cloudwatch/metric-stream/main.tf
+++ b/modules/cloudwatch/metric-stream/main.tf
@@ -14,7 +14,6 @@ resource "aws_cloudwatch_metric_stream" "this" {
   # If the options are not set correctly, the user will get an error at 'Plan' time and will be able to fix it before applying the changes.
   #
   ##########################################
-
   lifecycle {
     precondition {
       condition     = contains(["json", "opentelemetry1.0", "opentelemetry0.7"], local.output_format)
@@ -53,18 +52,18 @@ resource "aws_cloudwatch_metric_stream" "this" {
     }
   }
 
-  include_linked_accounts_metrics = local.include_linked_accounts_metrics
-
   dynamic "statistics_configuration" {
-    for_each = local.additional_statistics
+    for_each = local.statistics_configurations
     content {
-      additional_statistics = statistics_configuration.value["statistics"]
+      additional_statistics = statistics_configuration.value["additional_statistics"]
       include_metric {
-        metric_name = statistics_configuration.value["metric_names"][0]
+        metric_name = statistics_configuration.value["metric_name"]
         namespace   = statistics_configuration.value["namespace"]
       }
     }
   }
+
+  include_linked_accounts_metrics = local.include_linked_accounts_metrics
 
   tags = merge(var.tags, lookup(var.stream, "tags", {}))
 }

--- a/modules/cloudwatch/metric-stream/outputs.tf
+++ b/modules/cloudwatch/metric-stream/outputs.tf
@@ -8,6 +8,15 @@ output "tags_set" {
   description = "The tags set for the module."
 }
 
+output "feature_flags" {
+  value = {
+    is_stream_enabled                   = local.is_stream_enabled
+    is_statistics_configuration_enabled = local.is_statistics_configuration_enabled
+    is_include_filters_enabled          = local.is_include_filters_enabled
+    is_exclude_filters_enabled          = local.is_exclude_filters_enabled
+  }
+}
+
 output "cloudwatch_metric_stream_id" {
   value       = local.is_stream_enabled ? join("", aws_cloudwatch_metric_stream.this.*.id) : ""
   description = "The ID of the CloudWatch Metric Stream."


### PR DESCRIPTION
Added feature flags output to provide module users with information about various feature flags like stream enablement, statistics configuration, include filters, and exclude filters. This change enhances visibility and configurability for the CloudWatch metric stream module.